### PR TITLE
Added license information to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,14 @@
         <maven.build.timestamp.format>yyyy/MM/dd HH:mm:ss</maven.build.timestamp.format>
     </properties>
 
+    <licenses>
+        <license>
+            <name>BSD-2-Clause</name>
+            <url>https://spdx.org/licenses/BSD-2-Clause.html</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
The pom.xml file has the option to specify the license information.
Having this information available in the pom file makes it easier for
people using the library to integrate this information with tools. For
example have a report listing all licenses of 3th party repositories,
having automated checks whether all used 3th party libs have a license
allowing them to be used, ... .